### PR TITLE
Refactor eval download route handler

### DIFF
--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -33,7 +33,7 @@ exports.upload = function(req, cb) {
       console.log("time 3");
     });
 
-  //get signed URL to include in email to company   
+  //get signed URL to include in email to company
 /*  var url = s3.getSignedUrl('putObject', params);
   console.log('The URL is', url);*/
 
@@ -53,6 +53,7 @@ exports.upload = function(req, cb) {
   });
 };
 
+// this would go away after a full refactor
 exports.downloadEvaluation = function (req, res) {
   companies.getOpportunity(req, function(opportunity) {
     var filename = opportunity.file;
@@ -61,4 +62,10 @@ exports.downloadEvaluation = function (req, res) {
     console.log('The URL is', url);
     res.redirect(url);
   });
+};
+
+exports.getDownloadUrl = function (filename) {
+  var params = {Bucket: 'paved-test', Key: filename};
+  var url = s3.getSignedUrl('getObject', params);
+  return url;
 };

--- a/models/opportunities.js
+++ b/models/opportunities.js
@@ -107,6 +107,7 @@ exports.show = function(req, res) {
 	});
 };
 
+// this would go away after a full refactor
 exports.getOpportunity = function(req, done) {
 	var companyId = req.params.companyId;
 	var evalId = req.params.id;
@@ -115,4 +116,13 @@ exports.getOpportunity = function(req, done) {
 		var opportunity = company.opportunities.id(evalId);
 		done(opportunity);
 	});
+};
+
+exports.getOpportunity = function(companyId, evalId, done) {
+    Company.findById(companyId, function (err, company) {
+        if (err) return done(err);
+
+        var opportunity = company.opportunities.id(evalId);
+        done(null, opportunity);
+    });
 };

--- a/models/users.js
+++ b/models/users.js
@@ -8,7 +8,7 @@ var userSchema = mongoose.Schema({
 	profile				: {
 		firstname		: String,
 		lastname		: String,
-  	charges			: [] 
+  	charges			: []
 	},
 	localAuth			: {
 		email   		: String,
@@ -40,6 +40,7 @@ User.saveChargeToUser = function(req) {
 	});
 };
 
+// this would go away after a full refactor
 User.checkPriorCharges = function(req, cb) {
 	User.findById(req.user, function (err, user) {
 		if (err) return console.log(err);
@@ -52,6 +53,16 @@ User.checkPriorCharges = function(req, cb) {
 		};
 		cb(hasEval);
 	});
+};
+
+userSchema.methods.hasPurchasedEval = function(evalId, cb) {
+    var charges = this.profile.charges || [];
+    for (var i = 0; i < charges.length; i++) {
+        if (evalId === charges[i]) {
+            return cb(null, true);
+        }
+    }
+    return cb(null, false);
 };
 
 module.exports = mongoose.model('User', userSchema);


### PR DESCRIPTION
Here is a PR showing an example of the route handler changes we talked about. Notice that only the route handler itself accesses anything on `req.` or `res.`; the `amazon` module is _only_ concerned with AWS stuff (in fact that function does so little you could probably remove it); `getOpportunity` gets the required company and eval IDs via direct parameters; `hasPurchasedEval` is a method directly on the `User` instance and also gets its parameter passed in directly; and the route handler acts as the point of coordination.

Each of the non-route-handler methods should now be a simpler to reason about, much easier to reuse, and much easier to test.
